### PR TITLE
SLING-7496 Factory configurations get deleted on update()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.15.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/apache/sling/installer/factories/configuration/impl/ConfigTaskCreator.java
+++ b/src/main/java/org/apache/sling/installer/factories/configuration/impl/ConfigTaskCreator.java
@@ -106,7 +106,7 @@ public class ConfigTaskCreator
             } else {
                 pid = (event.getPid().startsWith(event.getFactoryPid() + '.') ?
                         event.getPid().substring(event.getFactoryPid().length() + 1) : event.getPid());
-                id = event.getFactoryPid() + '.' + event.getPid();
+                id = event.getFactoryPid() + '.' + pid;
             }
             if ( event.getType() == ConfigurationEvent.CM_DELETED ) {
                 final Coordinator.Operation op = Coordinator.SHARED.get(event.getPid(), event.getFactoryPid(), true);
@@ -191,22 +191,7 @@ public class ConfigTaskCreator
         final String configPid;
         int n = pid.indexOf('-');
         if (n > 0) {
-            // quick check if this is an existing configuration
-            final String fString = pid.substring(0, n);
-            final String cString = pid.substring(n + 1);
-            boolean useExtendedPid = false;
-            try {
-                if ( ConfigUtil.getConfiguration(this.configAdmin, fString, fString + '.' + cString) != null ) {
-                    useExtendedPid = true;
-                }
-            } catch ( final Exception ignore) {
-                // ignore this
-            }
-            if ( useExtendedPid ) {
-                configPid = fString + '.' + cString;
-            } else {
-                configPid = pid.substring(n + 1);
-            }
+            configPid = pid.substring(n + 1);
             factoryPid = pid.substring(0, n);
         } else {
             factoryPid = null;

--- a/src/main/java/org/apache/sling/installer/factories/configuration/impl/ConfigUtil.java
+++ b/src/main/java/org/apache/sling/installer/factories/configuration/impl/ConfigUtil.java
@@ -194,6 +194,12 @@ abstract class ConfigUtil {
                         + "))");
             }
             if (configs == null || configs.length == 0) {
+                configs = ca.listConfigurations("(&("
+                        + ConfigurationAdmin.SERVICE_FACTORYPID + "=" + encode(factoryPid)
+                        + ")(" + Constants.SERVICE_PID + "=" + encode(factoryPid + "." + configPid)
+                        + "))");
+            }
+            if (configs == null || configs.length == 0) {
                 // check for old style with alias pid
                 configs = ca.listConfigurations(
                         "(&(" + ConfigurationAdmin.SERVICE_FACTORYPID


### PR DESCRIPTION
The factory prefix was prepended twice which caused the installer to
think that the original configuration being updated was gone, which
triggered a callback to Configuration.delete();