### PR TITLE
SLING-7496 Factory config deleted with ConfigAdmin immediately after creation

### DIFF
--- a/src/main/java/org/apache/sling/installer/factories/configuration/impl/AbstractConfigTask.java
+++ b/src/main/java/org/apache/sling/installer/factories/configuration/impl/AbstractConfigTask.java
@@ -80,7 +80,12 @@ abstract class AbstractConfigTask extends InstallTask {
         if ( this.aliasPid == null || this.factoryPid == null ) {
             return null;
         }
-        final String alias = factoryPid + "." + this.aliasPid;
+        final String alias;
+        if (this.aliasPid.startsWith(this.factoryPid)) {
+            alias = this.aliasPid;
+        } else {
+            alias = this.factoryPid + "." + this.aliasPid;
+        }
         final int pos = this.getResource().getEntityId().indexOf(':');
         if ( this.getResource().getEntityId().substring(pos + 1).equals(alias) ) {
             return null;


### PR DESCRIPTION
The PID alias should not have the factory pid prefix twice. This fix is
needed to address the
ConfigInstallTest.testInstallUpdateRemoveTemplateConfigFactory() failure
that was introduced with the previous commit for SLING-7496